### PR TITLE
build: copy recovery.img to BOOTABLE_IMAGES only when it's actually used

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1989,7 +1989,9 @@ endif # BOARD_USES_RECOVERY_AS_BOOT
 	@# Prebuilt boot images
 	$(hide) mkdir -p $(zip_root)/BOOTABLE_IMAGES
 	$(hide) $(ACP) $(INSTALLED_BOOTIMAGE_TARGET) $(zip_root)/BOOTABLE_IMAGES/
+ifneq ($(BOARD_USES_RECOVERY_AS_BOOT),true)
 	$(hide) $(ACP) $(INSTALLED_RECOVERYIMAGE_TARGET) $(zip_root)/BOOTABLE_IMAGES/
+endif
 ifdef BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE
 	@# Contents of the vendor image
 	$(hide) $(call package_files-copy-root, \


### PR DESCRIPTION
Devices like marlin and sailfish don't have full recovery.img.
Let's copy recovery.img only when BOARD_USES_RECOVERY_AS_BOOT is not used.

Change-Id: Ieab5a0ff0b4c408c5f2e05fc74a2eba274694ab9