### PR TITLE
Updates (#39)

### DIFF
--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -528,8 +528,11 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
     buildhst = GetBuildProp("ro.build.host", OPTIONS.info_dict)
     device = GetBuildProp("ro.rr.device", OPTIONS.info_dict)
     androidver = GetBuildProp("ro.build.version.release", OPTIONS.info_dict)
-    manufacturer = GetBuildProp("ro.product.manufacturer", OPTIONS.info_dict)
-    maintainer = GetBuildProp("ro.build.user", OPTIONS.info_dict)
+    manufacturer = GetBuildProp("ro.product.manufacturer", OPTIONS.info_dict, False)
+    density = GetBuildProp("ro.sf.lcd_density", OPTIONS.info_dict, False)
+    maintainer = GetBuildProp("ro.rr.maintainer", OPTIONS.info_dict, False)
+    if maintainer is None:
+        maintainer = GetBuildProp("ro.build.user", OPTIONS.info_dict)
     sdkver = GetBuildProp("ro.build.version.sdk", OPTIONS.info_dict)
     script.Print(" **************** Software *****************");
     script.Print(" OS ver: %s"%(buildid));
@@ -552,8 +555,12 @@ else if get_stage("%(bcb_dev)s") == "3/3" then
     script.Print(" **************** Hardware *****************");
     script.Print(" Device codename: %s"%(device));
     script.Print("");
-    script.Print(" Manufacturer: %s"%(manufacturer));
-    script.Print("");
+    if density is not None:
+        script.Print(" Density: %s"%(density));
+        script.Print("");
+    if manufacturer is not None:
+        script.Print(" Manufacturer: %s"%(manufacturer));
+        script.Print("");
     script.Print(" *******************************************");
     
 
@@ -656,12 +663,15 @@ def WriteMetadata(metadata, output_zip):
                      compress_type=zipfile.ZIP_STORED)
 
 
-def GetBuildProp(prop, info_dict):
+def GetBuildProp(prop, info_dict, raise_error=True):
   """Return the fingerprint of the build of a given target-files info_dict."""
   try:
     return info_dict.get("build.prop", {})[prop]
   except KeyError:
-    raise common.ExternalError("couldn't find %s in build.prop" % (prop,))
+    if raise_error:
+      raise common.ExternalError("couldn't find %s in build.prop" % (prop,))
+    else:
+      return None
 
 
 def HandleDowngradeMetadata(metadata):


### PR DESCRIPTION
* Add raise_error param on GetBuildProp method
Some devices may not have a specific parameter, so don't let the build fails

* releasetools: Get maintainer name from ro.rr.maintainer

I don't want UNIX username displaying as maintainer (jenkins feelings)

* ota_from_target_files: Add density and add check on manufacturer name